### PR TITLE
Init main infra and scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Services
+QDRANT_URL=http://localhost:6333
+OLLAMA_URL=http://localhost:11434
+
+# Embeddings
+EMBED_MODEL=nomic-embed-text
+
+# Collections
+COLLECTION_PREFIX=rag_
+DEFAULT_CORPUS=default

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+ENV ?= .env
+include $(ENV)
+export
+
+help:
+	@echo "make up / down / ps / logs         - manage services"
+	@echo "make pull-models                    - pull embedding model in ollama"
+	@echo "make ingest DIR=./workspace         - ingest md/docx into Qdrant"
+	@echo "make search Q='your query'          - test retrieval"
+	@echo "make mcp                            - run MCP server locally"
+
+up:
+	docker compose -f infra/docker-compose.yml up -d
+
+down:
+	docker compose -f infra/docker-compose.yml down
+
+ps:
+	docker compose -f infra/docker-compose.yml ps
+
+logs:
+	docker compose -f infra/docker-compose.yml logs -f
+
+pull-models:
+	@echo "Pulling model: $(EMBED_MODEL)"
+	curl -fsS -X POST "$(OLLAMA_URL)/api/pull" -H 'content-type: application/json' \
+	  -d "{\"name\":\"$(EMBED_MODEL)\"}"
+
+# --- Ingest/search via host ---
+INGESTOR := apps/ingestor/.venv/bin/python apps/ingestor/src/ingest.py
+SEARCHER := apps/ingestor/.venv/bin/python apps/ingestor/src/search.py
+
+ingest:
+	@if [[ -z "$(DIR)" ]]; then echo "Usage: make ingest DIR=./docs"; exit 1; fi
+	$(INGESTOR) --path "$(DIR)" --corpus "$(DEFAULT_CORPUS)" \
+	  --qdrant "$(QDRANT_URL)" --ollama "$(OLLAMA_URL)" --model "$(EMBED_MODEL)" \
+	  --collection-prefix "$(COLLECTION_PREFIX)"
+
+search:
+	@if [[ -z "$(Q)" ]]; then echo "Usage: make search Q='question'"; exit 1; fi
+	$(SEARCHER) --query "$(Q)" --corpus "$(DEFAULT_CORPUS)" \
+	  --qdrant "$(QDRANT_URL)" --ollama "$(OLLAMA_URL)" --model "$(EMBED_MODEL)" \
+	  --collection-prefix "$(COLLECTION_PREFIX)"
+
+# --- MCP server (run on host) ---
+mcp:
+	cd apps/mcp-server && node dist/index.js

--- a/apps/ingestor/requirements.txt
+++ b/apps/ingestor/requirements.txt
@@ -1,0 +1,5 @@
+qdrant-client==1.12.0
+requests>=2.31.0
+markdown-it-py>=3.0.0
+tqdm>=4.66.0
+python-docx>=1.1.0

--- a/apps/ingestor/src/ingest.py
+++ b/apps/ingestor/src/ingest.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import argparse, hashlib, os, sys, time, json, subprocess, tempfile
+from pathlib import Path
+from typing import List, Tuple
+import requests
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qm
+
+def sha1(s: str) -> str: return hashlib.sha1(s.encode("utf-8")).hexdigest()
+
+def docx_to_md(path: Path) -> str:
+    # prefer pandoc if available, fallback to python-docx (simpler)
+    try:
+        subprocess.run(["pandoc", "-v"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        out = subprocess.check_output(["pandoc", "-f", "docx", "-t", "gfm", str(path)])
+        return out.decode("utf-8", errors="ignore")
+    except Exception:
+        from docx import Document
+        d = Document(str(path))
+        return "\n".join(p.text for p in d.paragraphs)
+
+def read_text(p: Path) -> str:
+    if p.suffix.lower() == ".docx":
+        return docx_to_md(p)
+    return p.read_text(encoding="utf-8", errors="ignore")
+
+def chunk_markdown(md: str, target_tokens: int = 800, overlap: int = 120) -> List[Tuple[int, str, str]]:
+    # very simple tokenizer proxy: ~4 chars ≈ 1 token
+    max_len = target_tokens * 4
+    olap_len = overlap * 4
+    chunks = []
+    start = 0
+    n = 0
+    while start < len(md):
+        end = min(len(md), start + max_len)
+        # try to end at a heading or paragraph break
+        cut = md.rfind("\n## ", start, end)
+        if cut == -1:
+            cut = md.rfind("\n# ", start, end)
+        if cut == -1:
+            cut = md.rfind("\n\n", start, end)
+        if cut == -1 or cut <= start + max_len * 0.6:
+            cut = end
+        text = md[start:cut].strip()
+        if text:
+            section = ""
+            # capture last heading
+            hidx = md.rfind("\n#", 0, cut)
+            if hidx != -1:
+                section = md[hidx:md.find("\n", hidx+1)]
+            chunks.append((n, text, section))
+            n += 1
+        start = max(cut - olap_len, cut)
+    return chunks
+
+def ensure_collection(client: QdrantClient, name: str, dim: int):
+    try:
+        client.get_collection(name)
+    except Exception:
+        client.recreate_collection(
+            collection_name=name,
+            vectors_config=qm.VectorParams(size=dim, distance=qm.Distance.COSINE),
+        )
+
+def embed(ollama_url: str, model: str, texts: List[str]) -> List[List[float]]:
+    resp = requests.post(f"{ollama_url}/api/embeddings",
+                         json={"model": model, "input": texts}, timeout=120)
+    resp.raise_for_status()
+    data = resp.json()
+    # compatible with common ollama response shapes
+    if "embeddings" in data:
+        return data["embeddings"]
+    if isinstance(data, dict) and "data" in data:  # some variants
+        return [d["embedding"] for d in data["data"]]
+    raise RuntimeError("Unexpected embeddings response")
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", required=True)
+    ap.add_argument("--corpus", default="default")
+    ap.add_argument("--qdrant", required=True)
+    ap.add_argument("--ollama", required=True)
+    ap.add_argument("--model", default="nomic-embed-text")
+    ap.add_argument("--collection-prefix", default="rag_")
+    args = ap.parse_args()
+
+    root = Path(args.path)
+    files = [p for p in root.rglob("*") if p.suffix.lower() in (".md", ".markdown", ".docx")]
+    if not files:
+        print("No .md/.docx found", file=sys.stderr)
+        return 0
+
+    # Assume embedding dims (nomic-embed-text=768). You can probe once by calling /api/embeddings
+    dim = 768
+    collection = f"{args.collection_prefix}{args.corpus}"
+    client = QdrantClient(url=args.qdrant, prefer_grpc=False)
+    ensure_collection(client, collection, dim)
+
+    for f in files:
+        text = read_text(f)
+        doc_id = sha1(f"{f}:{f.stat().st_size}:{int(f.stat().st_mtime)}")
+        chunks = chunk_markdown(text)
+        if not chunks: continue
+
+        # delete old points for this doc_id
+        client.delete(collection, qm.Filter(must=[qm.FieldCondition(key="doc_id", match=qm.MatchValue(value=doc_id))]), wait=True)
+
+        batch_texts = [c[1] for c in chunks]
+        vecs = embed(args.ollama, args.model, batch_texts)
+
+        points = []
+        for (chunk_id, chunk_text, section), vec in zip(chunks, vecs):
+            pid = sha1(f"{doc_id}:{chunk_id}")
+            payload = {
+                "corpus_id": args.corpus,
+                "doc_id": doc_id,
+                "source_path": str(f),
+                "chunk_id": chunk_id,
+                "chunk_text": chunk_text,
+                "section": section.strip(),
+                "timestamp": int(time.time()),
+            }
+            points.append(qm.PointStruct(id=pid, vector=vec, payload=payload))
+
+        client.upsert(collection_name=collection, points=points, wait=True)
+        print(f"Upserted {len(points)} chunks from {f}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/ingestor/src/search.py
+++ b/apps/ingestor/src/search.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import argparse, json
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qm
+import requests
+
+def embed(ollama_url: str, model: str, text: str):
+    r = requests.post(f"{ollama_url}/api/embeddings", json={"model": model, "input":[text]}, timeout=60)
+    r.raise_for_status()
+    return r.json()["embeddings"][0]
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--query", required=True)
+    ap.add_argument("--corpus", default="default")
+    ap.add_argument("--qdrant", required=True)
+    ap.add_argument("--ollama", required=True)
+    ap.add_argument("--model", default="nomic-embed-text")
+    ap.add_argument("--collection-prefix", default="rag_")
+    ap.add_argument("--topk", type=int, default=8)
+    args = ap.parse_args()
+
+    vec = embed(args.ollama, args.model, args.query)
+    client = QdrantClient(url=args.qdrant, prefer_grpc=False)
+    collection = f"{args.collection_prefix}{args.corpus}"
+    res = client.search(
+        collection_name=collection,
+        query_vector=vec,
+        limit=args.topk,
+        with_payload=True,
+        query_filter=qm.Filter(must=[qm.FieldCondition(key="corpus_id", match=qm.MatchValue(value=args.corpus))]),
+    )
+    for i, r in enumerate(res, 1):
+        pl = r.payload or {}
+        print(f"\n#{i} score={r.score:.4f} {pl.get('source_path')}#{pl.get('section','').strip()}")
+        print("-" * 80)
+        print(pl.get("chunk_text","")[:1000])
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcp-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,86 @@
+import fetch from "node-fetch";
+
+const QDRANT_URL = process.env.QDRANT_URL || "http://localhost:6333";
+const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
+const EMBED_MODEL = process.env.EMBED_MODEL || "nomic-embed-text";
+const COLLECTION_PREFIX = process.env.COLLECTION_PREFIX || "rag_";
+
+type Json = any;
+
+async function readStdio(): Promise<void> {
+  process.stdin.setEncoding("utf8");
+  let buf = "";
+  process.stdin.on("data", async (chunk) => {
+    buf += chunk;
+    // naive framing: assume one JSON per line
+    let idx;
+    while ((idx = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      try {
+        const msg = JSON.parse(line);
+        const res = await handle(msg);
+        process.stdout.write(JSON.stringify(res) + "\n");
+      } catch (e: any) {
+        process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32603, message: String(e) }}) + "\n");
+      }
+    }
+  });
+}
+
+async function embed(input: string): Promise<number[]> {
+  const r = await fetch(`${OLLAMA_URL}/api/embeddings`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ model: EMBED_MODEL, input: [input] })
+  });
+  if (!r.ok) throw new Error(`embed failed: ${r.status}`);
+  const j = await r.json() as any;
+  return j.embeddings[0];
+}
+
+async function qdrantSearch(collection: string, vec: number[], corpus: string, top = 8): Promise<any[]> {
+  const r = await fetch(`${QDRANT_URL}/collections/${collection}/points/search`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      vector: vec, top,
+      with_payload: true,
+      filter: { must: [{ key: "corpus_id", match: { value: corpus } }] }
+    })
+  });
+  if (!r.ok) throw new Error(`qdrant search failed: ${r.status}`);
+  const j = await r.json() as any;
+  return j.result || [];
+}
+
+async function handle(msg: Json): Promise<Json> {
+  const { id, method, params } = msg;
+  if (method === "rag.search") {
+    const query = params?.query as string;
+    const corpus = params?.corpus_id ?? "default";
+    const top = params?.top_k ?? 8;
+    const vec = await embed(query);
+    const col = `${COLLECTION_PREFIX}${corpus}`;
+    const hits = await qdrantSearch(col, vec, corpus, top);
+    const items = hits.map((h: any) => {
+      const p = h.payload || {};
+      return {
+        text: p.chunk_text, score: h.score,
+        source_path: p.source_path, section: p.section,
+        doc_id: p.doc_id, chunk_id: p.chunk_id
+      };
+    });
+    return { jsonrpc: "2.0", id, result: { items } };
+  }
+  if (method === "rag.health") {
+    return { jsonrpc: "2.0", id, result: { qdrant: QDRANT_URL, ollama: OLLAMA_URL, model: EMBED_MODEL } };
+  }
+  return { jsonrpc: "2.0", id, error: { code: -32601, message: "Method not found" } };
+}
+
+readStdio().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports: ["6333:6333"]
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:6333/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  ollama:
+    image: ollama/ollama:latest
+    ports: ["11434:11434"]
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_KEEP_ALIVE=1h
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:11434/api/tags"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    # Uncomment for GPU
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - capabilities: ["gpu"]
+
+  # Optional: local dev containers for your apps (you can run them from host too)
+  # mcp-server:
+  #   build: ../apps/mcp-server
+  #   environment:
+  #     - QDRANT_URL=http://qdrant:6333
+  #     - OLLAMA_URL=http://ollama:11434
+  #     - EMBED_MODEL=${EMBED_MODEL:-nomic-embed-text}
+  #   depends_on: [qdrant, ollama]
+  #   ports: ["8711:8711"]
+
+volumes:
+  qdrant_data:
+  ollama_data:


### PR DESCRIPTION
This pull request introduces a local RAG (Retrieval-Augmented Generation) stack with Qdrant for vector storage, Ollama for embeddings, and supporting ingestion and search scripts. It provides a Makefile for common operations, environment variable configuration, and a simple MCP server for JSON-RPC search. The changes enable local document ingestion (Markdown/Docx), embedding, chunking, and semantic search, all orchestrated via Docker Compose and CLI scripts.

**Infrastructure & Configuration**

* Added `infra/docker-compose.yml` to run Qdrant and Ollama services locally, including persistent storage and health checks.
* Introduced `.env.example` for configuration of service URLs, embedding model, and collection/corpus names.
* Added a `Makefile` to streamline common workflows: starting/stopping services, pulling models, ingesting documents, and running searches.

**Ingestion & Search Scripts**

* Added `apps/ingestor/src/ingest.py` for chunking Markdown/Docx files, embedding their content, and upserting into Qdrant.
* Added `apps/ingestor/src/search.py` for embedding a query and retrieving top matching chunks from Qdrant.
* Specified new Python dependencies in `apps/ingestor/requirements.txt` for Qdrant, embedding, and document parsing.

**MCP Server (Node.js/TypeScript)**

* Introduced `apps/mcp-server` with a minimal JSON-RPC server (`src/index.ts`) to expose search and health endpoints, plus configuration and build scripts. [[1]](diffhunk://#diff-0f3adbdd2d8fad79a85835b2ef6951b9631aecd4dd3d60dcddba7e0406582bbdR1-R86) [[2]](diffhunk://#diff-0042c6f49b45eb82aa17a2d3e2dbe2bc45339039b4ed1f249276b619663af8e2R1-R16) [[3]](diffhunk://#diff-829b6cca451c3ab0dceb872f5e24f987de92153e399d6212daffb17f836d8ddaR1-R12)